### PR TITLE
Deleting draft posts that were not registered with "author" feature support

### DIFF
--- a/map_cap.php
+++ b/map_cap.php
@@ -252,8 +252,9 @@ function mc_map_meta_cap( $caps, $cap, $user_id, $args ){
 				} elseif ( 'trash' == $post->post_status ) {
 					if ('publish' == get_post_meta($post->ID, '_wp_trash_meta_status', true) )
 						$caps[0] = 'delete_published_' . $post_type_cap . '_posts';
+					else $caps[0] = 'delete_' . $post_type_cap . 's';
 				} else {
-					$caps[0] = 'delete_' . $post_type_cap . '_posts';
+					$caps[0] = 'delete_' . $post_type_cap . 's';
 				}
 			} else {
 				$caps[0] = $post_type_caps->edit_others_posts;


### PR DESCRIPTION
Attempts to address an issue where a custom post without the 'author' feature could not be trashed while having Draft status.
